### PR TITLE
Fix spelling errors

### DIFF
--- a/src/gdal_dem2rgb.cc
+++ b/src/gdal_dem2rgb.cc
@@ -73,7 +73,7 @@ void usage(const std::string &cmdname) {
 	printf("  -alpha-overlay                      Generate an RGBA image that can be used as a hillshade mask\n");
 	printf("\n");
 	printf("Shading:\n");
-	printf("  -exag slope_exageration             Exagerate slope (default: %.1f)\n", default_slope_exageration);
+	printf("  -exag slope_exageration             Exaggerate slope (default: %.1f)\n", default_slope_exageration);
 	printf("  -shade ambient diffuse specular_intensity specular_falloff          (default: %.1f, %.1f, %.1f, %.1f)\n",
 		default_shade_params[0], default_shade_params[1], default_shade_params[2], default_shade_params[3]);
 	printf("  -lightvec sun_x sun_y sun_z                                         (default: %.1f, %.1f, %.1f)\n",

--- a/src/gdal_get_projected_bounds.cc
+++ b/src/gdal_get_projected_bounds.cc
@@ -59,7 +59,7 @@ void usage(const std::string &cmdname) {
 	printf("  -t_bounds_wkt <fn>    File containing WKT for valid region of target SRS (optional)\n");
 	printf("  -s_srs <srs_def>      Source SRS\n");
 	printf("  -t_srs <srs_def>      Target SRS\n");
-	printf("  -report <out.ppm>     Ouput a graphical report (optional)\n");
+	printf("  -report <out.ppm>     Output a graphical report (optional)\n");
 	printf("\nOutput is the envelope of the source region projected into the target SRS.\n");
 	printf("If the -t_bounds_wkt option is given it will be used as a clip mask in the\n");
 	printf("projected space.\n");


### PR DESCRIPTION
The lintian QA tool reported some spelling errors for the Debian package build:
- Ouput -> Output
- Exagerate -> Exaggerate

Regarding the Debian package, is there an ETA for the 0.24 release? 0.23 was released quite some time ago.
